### PR TITLE
#23

### DIFF
--- a/resources/conceptmap/religion-ech11-to-fhir.xml
+++ b/resources/conceptmap/religion-ech11-to-fhir.xml
@@ -1,5 +1,66 @@
 <ConceptMap xmlns="http://hl7.org/fhir">
     <id value="religion-ech11-to-fhir"/>
+    <text>
+        <status value="generated"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <h2>ReligionECH011ToFHIRMapping (http://fhir.ch/ig/ch-core/ConceptMap/religion-ech11-to-fhir)</h2>
+            <p>Mapping from <a href="ValueSet-ech-11-religion.html">http://fhir.ch/ig/ch-core/ValueSet/ech-11-religion</a> to http://terminology.hl7.org/ValueSet/v3-ReligiousAffiliation/</p>
+            <p>DRAFT (not intended for production usage). Published on 04.12.2018 00:00:00 by HL7 Switzerland (HL7 Switzerland: <a href="https://www.hl7.ch/">https://www.hl7.ch/</a>). CC-BY-SA-4.0</p>
+            <br/>
+            <table class="grid">
+                <tr>
+                    <td>
+                        <b>Source Code</b>
+                    </td>
+                    <td>
+                        <b>Equivalence</b>
+                    </td>
+                    <td>
+                        <b>Destination Code</b>
+                    </td>
+                    <td>
+                        <b>Comment</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td>111 (evangelisch-reformierte (protestantische) Kirche)</td>
+                    <td>wider</td>
+                    <td>1077 (Protestant)</td>
+                    <td>doest not exactly match</td>
+                </tr>
+                <tr>
+                    <td>121 (römisch-katholische Kirche)</td>
+                    <td>equivalent</td>
+                    <td>1041 (Roman Catholic Church)</td>
+                    <td/>
+                </tr>
+                <tr>
+                    <td>122 (christkatholische / altkatholische Kirche)</td>
+                    <td>inexact</td>
+                    <td>1013 (Christian (non-Catholic, non-specific))</td>
+                    <td>doest not exactly match</td>
+                </tr>
+                <tr>
+                    <td>211 (israelitische Gemeinschaft / jüdische Glaubensgemeinschaft)</td>
+                    <td>wider</td>
+                    <td>1026 (Judaism)</td>
+                    <td/>
+                </tr>
+                <tr>
+                    <td>211201 (Israelitische Cultusgemeinde)</td>
+                    <td>wider</td>
+                    <td>1026 (Judaism)</td>
+                    <td/>
+                </tr>
+                <tr>
+                    <td>211301 (Jüdisch Liberale Gemeinde)</td>
+                    <td>wider</td>
+                    <td>1026 (Judaism)</td>
+                    <td/>
+                </tr>
+            </table>
+        </div>
+    </text>
     <url value="http://fhir.ch/ig/ch-core/ConceptMap/religion-ech11-to-fhir" />
     <version value="0.1.0"/>
     <name value="ReligionECH011ToFHIRMapping" />
@@ -26,14 +87,14 @@
     <targetUri value="http://terminology.hl7.org/ValueSet/v3-ReligiousAffiliation/" />
     <group>
         <source value="http://fhir.ch/ig/ch-core/CodeSystem/ech-11-religion"/>
-        <target value="http://terminology.hl7.org/CodeSystem/v3-religion"/>
+        <target value="http://terminology.hl7.org/CodeSystem/v3-ReligiousAffiliation"/>
         <element>
             <code value="111"/>
             <display value="evangelisch-reformierte (protestantische) Kirche"/>
             <target>
                 <code value="1077"/>
                 <display value="Protestant"/>
-                <equivalence value="inexact"/>
+                <equivalence value="wider"/>
                 <comment value="doest not exactly match" />
             </target>
         </element>
@@ -50,9 +111,10 @@
             <code value="122"/>
             <display value="christkatholische / altkatholische Kirche"/>
             <target>
-                <code value="1034"/>
-                <display value="non-Roman Catholic"/>
-                <equivalence value="wider"/>
+                <code value="1013"/>
+                <display value="Christian (non-Catholic, non-specific)"/>
+                <equivalence value="inexact"/>
+                <comment value="doest not exactly match" />
             </target>
         </element>
         <element>
@@ -61,7 +123,7 @@
             <target>
                 <code value="1026"/>
                 <display value="Judaism"/>
-                <equivalence value="equivalent"/>
+                <equivalence value="wider"/>
             </target>
         </element>
         <element>
@@ -80,22 +142,6 @@
                 <code value="1026"/>
                 <display value="Judaism"/>
                 <equivalence value="wider"/>
-            </target>
-        </element>
-        <element>
-            <code value="211301"/>
-            <display value="Jüdisch Liberale Gemeinde"/>
-            <target>
-                <code value="1026"/>
-                <display value="Judaism"/>
-                <equivalence value="wider"/>
-            </target>
-        </element>
-        <element>
-            <code value="000"/>
-            <display value="unbekannt"/>
-            <target>
-                <equivalence value="unmatched"/>
             </target>
         </element>
     </group>


### PR DESCRIPTION
Cleared discrepancy to CDA-Mapping

- Add text narrative to ConceptMap resource, because the equivalence values in the output are displayed incorrectly. See GForce-Ticket: https://chat.fhir.org/#narrow/stream/179297-committers.2Fnotification/topic/tracker-item/near/180015334

- The code 000 (unbekannt)  is omitted from the mapping because there is no corresponding value in the target valueset.