### PR TITLE
fix Practitioner example: change speciality to a valid value from DocumentEntry.authorSpeciality

### DIFF
--- a/input/examples/practitionerrole/HPWengerRole.xml
+++ b/input/examples/practitionerrole/HPWengerRole.xml
@@ -20,8 +20,8 @@
     <specialty>
         <coding>
             <system value="urn:oid:2.16.756.5.30.1.127.3.5"/>
-            <code value="1001"/>
-            <display value="General medicine"/>
+            <code value="1040"/>
+            <display value="General medical practitioner"/>
         </coding>
     </specialty>
 </PractitionerRole> 


### PR DESCRIPTION
PractitionerRole example HPWengerRole has an speciality entry of 1001/General Medicine which is not in the current ValueSet anymore: https://fhir.ch/ig/ch-epr-term/ValueSet-DocumentEntry.authorSpeciality.html

http://fhir.ch/ig/ch-core/PractitionerRole-HPWengerRole.xml.html

provided a valid code 1040 / General medical practitioner

https://github.com/hl7ch/ch-core/issues/63