### PR TITLE
fix for incorrect epr-spid validation

### DIFF
--- a/input/ch.fhir.ig.ch-core.xml
+++ b/input/ch.fhir.ig.ch-core.xml
@@ -156,6 +156,14 @@
     </resource>
     <resource>
       <reference>
+        <reference value="Patient/ManuelaMuster"/>
+      </reference>
+      <name value="ManuelaMuster"/>
+      <description value="Example for Patient with EPR-SPID ending on 0"/>
+      <exampleCanonical value="http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient"/>
+    </resource>
+    <resource>
+      <reference>
         <reference value="Patient/PersonEch011"/>
       </reference>
       <name value="PersonEch011"/>

--- a/input/examples/patient/ManuelaMuster.xml
+++ b/input/examples/patient/ManuelaMuster.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Patient xmlns="http://hl7.org/fhir">
+  <id value="ManuelaMuster"/>
+  <meta>
+    <profile value="http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient"/>
+  </meta>
+  <text>
+    <status value="additional"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>
+        <b>id</b>: ManuelaMuster
+      </p>
+      <p>
+        <b>meta</b>: 
+      </p>
+      <p>
+        <b>identifier</b>: 761337615317835750
+      </p>
+      <p>
+        <b>name</b>: Manuela Muster 
+      </p>
+      <p>
+        <b>gender</b>: FEMALE
+      </p>
+      <p>
+        <b>birthDate</b>: Feb 21, 1997
+      </p>
+      <p>
+        <b>maritalStatus</b>: in eingetragener Partnerschaft 
+        <span style="background: LightGoldenRodYellow">(Details : {http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus code &#39;6&#39; = &#39;6&#39;, given as &#39;in eingetragener Partnerschaft&#39;})</span>
+      </p>
+      <h3>Communications</h3>
+      <table class="grid">
+        <tr>
+          <td>-</td>
+          <td>
+            <b>Language</b>
+          </td>
+          <td>
+            <b>Preferred</b>
+          </td>
+        </tr>
+        <tr>
+          <td>*</td>
+          <td>Deutsch (Schweiz) 
+            <span style="background: LightGoldenRodYellow">(Details : {urn:ietf:bcp:47 code &#39;de-CH&#39; = &#39;German (Region=Switzerland))</span>
+          </td>
+          <td>true</td>
+        </tr>
+      </table>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/patient-birthPlace">
+    <valueAddress>
+      <city value="Paris"/>
+      <country value="Frankreich"/>
+    </valueAddress>
+  </extension>
+  <extension url="http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient-ech-11-placeoforigin">
+    <valueAddress>
+      <city value="Köniz"/>
+      <state value="BE"/>
+    </valueAddress>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/patient-religion">
+    <valueCodeableConcept>
+      <coding>
+        <system value="http://terminology.hl7.org/CodeSystem/v3-ReligiousAffiliation"/>
+        <code value="1077"/>
+        <display value="Protestant"/>
+      </coding>
+    </valueCodeableConcept>
+  </extension>
+  <identifier>
+    <system value="urn:oid:2.16.756.5.30.1.127.3.10.3"/>
+    <value value="761337615317835750"/>
+</identifier>    
+  <name>
+    <family value="Muster"/>
+    <given value="Manuela"/>
+  </name>
+  <gender value="female"/>
+  <birthDate value="1997-02-21"/>
+  <maritalStatus>
+    <coding>
+      <system value="http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus"/>
+      <code value="6"/>
+      <display value="in eingetragener Partnerschaft"/>
+    </coding>
+  </maritalStatus>
+  <communication>
+    <language>
+      <coding>
+        <system value="urn:ietf:bcp:47"/>
+        <code value="de-CH"/>
+      </coding>
+      <text value="Deutsch (Schweiz)"/>
+    </language>
+    <preferred value="true"/>
+  </communication>
+</Patient>

--- a/input/resources/structuredefinition/ch-core-epr-spid-identifier.xml
+++ b/input/resources/structuredefinition/ch-core-epr-spid-identifier.xml
@@ -60,21 +60,19 @@
         <key value="epr-spid-length"/>
         <severity value="error"/>
         <human value="EPR-SPID must be exactly 18 characters long"/>
-        <expression value="value.matches(&#39;^[0-9]{18}$&#39;)"/>
-      </constraint>
-      <constraint>
-        <key value="epr-spid-modulus-10"/>
-        <severity value="error"/>
-        <human value="EPR-SPID must pass the modulus 10 check - https://www.gs1.org/services/how-calculate-check-digit-manually"/>
-        <expression value="((&#xA; 68 + (value.substring(8,1).toInteger()*3)+&#xA;    (value.substring(9,1).toInteger()*1)+&#xA;    (value.substring(10,1).toInteger()*3)+&#xA;    (value.substring(11,1).toInteger()*1)+&#xA;    (value.substring(12,1).toInteger()*3)+&#xA;    (value.substring(13,1).toInteger()*1)+&#xA;    (value.substring(14,1).toInteger()*3)+&#xA;    (value.substring(15,1).toInteger()*1)+&#xA;    (value.substring(16,1).toInteger()*3)&#xA;    ) mod(10)+value.substring(17,1).toInteger()=10)"/>
-        <source value=""/>
+        <expression value="value.matches('^[0-9]{18}$')"/>
       </constraint>
       <constraint>
         <key value="epr-spid-startswith76133761"/>
         <severity value="error"/>
         <human value="EPR-SPID must start with 76133761"/>
         <expression value="value.startsWith('76133761')"/>
-        <source value=""/>
+      </constraint>
+      <constraint>
+        <key value="epr-spid-modulus-10"/>
+        <severity value="error"/>
+        <human value="EPR-SPID must pass the modulus 10 check - https://www.gs1.org/services/how-calculate-check-digit-manually"/>
+        <expression value="(((10-((68+(value.substring(8,1).toInteger()*3)+(value.substring(9,1).toInteger()*1)+(value.substring(10,1).toInteger()*3)+(value.substring(11,1).toInteger()*1)+(value.substring(12,1).toInteger()*3)+(value.substring(13,1).toInteger()*1)+(value.substring(14,1).toInteger()*3)+(value.substring(15,1).toInteger()*1)+(value.substring(16,1).toInteger()*3))mod(10)))mod(10))=value.substring(17,1).toInteger())"/>
       </constraint>
     </element>
   </differential>


### PR DESCRIPTION
- fixed constraint epr-spid failing on epr-spid's with a check digit 0.
- added ManuelaMuster (ch-core-patient) as an example containing an epr-spid where the check digit is 0.
- adjusted ch.fhir.ig.ch-core.xml