### PR TITLE
Replace deprecated extension iso21090-SC-coding with iso21090-codedSt…

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -42,7 +42,7 @@ Alias: $ech-11-maritalstatus =                      http://fhir.ch/ig/ch-core/Co
 Alias: $ech-11 =                                    http://fhir.ch/ig/ch-core/CodeSystem/ech-11
 
 Alias: $patient-birthPlace =                        http://hl7.org/fhir/StructureDefinition/patient-birthPlace
-Alias: $iso21090-SC-coding =                        http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding
+Alias: $iso21090-SC-coding =                        http://hl7.org/fhir/StructureDefinition/iso21090-codedString
 Alias: $iso21090-ADXP-streetName =                  http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName
 Alias: $iso21090-ADXP-houseNumber =                 http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber
 Alias: $iso21090-ADXP-unitID =                      http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-unitID

--- a/input/fsh/instances/patient/ElisabethBroennimannByBFH.fsh
+++ b/input/fsh/instances/patient/ElisabethBroennimannByBFH.fsh
@@ -22,7 +22,7 @@ Description: "Patient with insurance card number as identifier, contact details,
 * address[=].postalCode = "2500"
 * address[=].state = "BE"
 * address[=].country = "Schweiz"
-* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding"
+* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-codedString"
 * address[=].country.extension.valueCoding = urn:iso:std:iso:3166#CH
 /* test cases for invariant ch-addr-2 
 // [1] ch-addr-2 correct
@@ -32,7 +32,7 @@ Description: "Patient with insurance card number as identifier, contact details,
 * address[=].postalCode = "2500"
 * address[=].state = "BE"
 * address[=].country = "Schweiz"
-* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding"
+* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-codedString"
 * address[=].country.extension.valueCoding = urn:iso:std:iso:3166#CHE
 // [2] ch-addr-2 correct
 * address[+].use = #home
@@ -48,7 +48,7 @@ Description: "Patient with insurance card number as identifier, contact details,
 * address[=].postalCode = "2500"
 * address[=].state = "BE"
 * address[=].country = "Schweiz"
-* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding"
+* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-codedString"
 * address[=].country.extension.valueCoding = urn:iso:std:iso:3166#DE
 // [4] ch-addr-2 incorrect
 * address[+].use = #home
@@ -57,7 +57,7 @@ Description: "Patient with insurance card number as identifier, contact details,
 * address[=].postalCode = "2500"
 * address[=].state = "Bern"
 * address[=].country = "Schweiz"
-* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding"
+* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-codedString"
 * address[=].country.extension.valueCoding = urn:iso:std:iso:3166#CH
 // [5] ch-addr-2correct
 * address[+].use = #home
@@ -66,7 +66,7 @@ Description: "Patient with insurance card number as identifier, contact details,
 * address[=].postalCode = "2500"
 * address[=].state = "Bern"
 * address[=].country = "Schweiz"
-* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding"
+* address[=].country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-codedString"
 * address[=].country.extension.valueCoding = urn:iso:std:iso:3166#DE
 */
 * maritalStatus.coding[0] = $ech-11-maritalstatus#2 "verheiratet"

--- a/input/fsh/instances/patient/PersonEch011.fsh
+++ b/input/fsh/instances/patient/PersonEch011.fsh
@@ -63,7 +63,7 @@ Description: "Patient eCH-011 with names, marital status and separation type, de
 * contact.address.line[=].extension[=].valueString = "12345678"
 * contact.address.city = "Ort"
 * contact.address.postalCode = "PLZ"
-* contact.address.country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding"
+* contact.address.country.extension.url = "http://hl7.org/fhir/StructureDefinition/iso21090-codedString"
 * contact.address.country.extension.valueCoding = urn:iso:std:iso:3166#CH
 * contact.address.country = "Schweiz"
 // Zustelladresse falls es nicht die Adresse des Patienten direkt ist

--- a/input/fsh/instances/patient/UpiEprTestKrcmarevic.fsh
+++ b/input/fsh/instances/patient/UpiEprTestKrcmarevic.fsh
@@ -14,7 +14,7 @@ Description: "Test Patient from UPI for Swiss EPR Projectathon"
 * extension[placeOfBirth].valueAddress.city.extension[bfs].url = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-ech-7-municipalityid"
 * extension[placeOfBirth].valueAddress.city.extension[bfs].valueString = "261"
 * extension[placeOfBirth].valueAddress.city = "Zürich"
-* extension[placeOfBirth].valueAddress.country.extension[countrycode].url = "http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding"
+* extension[placeOfBirth].valueAddress.country.extension[countrycode].url = "http://hl7.org/fhir/StructureDefinition/iso21090-codedString"
 * extension[placeOfBirth].valueAddress.country.extension[countrycode].valueCoding = urn:iso:std:iso:3166#CH
 * extension[placeOfBirth].valueAddress.country = "Switzerland"
 

--- a/input/fsh/invariants/ch-addr.fsh
+++ b/input/fsh/invariants/ch-addr.fsh
@@ -7,7 +7,7 @@ Expression: "((value.code.length()=2) and value.code.memberOf('http://hl7.org/fh
 Invariant: ch-addr-2
 Description: "For a Swiss address, a canton abbreviation from the value set 'eCH-0007 Canton Abbreviation' must be used."
 Severity: #error
-Expression: "country.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding').empty() or 
-            (country.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding').value.code.startsWith('CH') = false) or 
-            (country.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding').value.code.startsWith('CH').exists() and 
+Expression: "country.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/iso21090-codedString').empty() or 
+            (country.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/iso21090-codedString').value.code.startsWith('CH') = false) or 
+            (country.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/iso21090-codedString').value.code.startsWith('CH').exists() and 
              (state.empty() or state.memberOf('http://fhir.ch/ig/ch-core/ValueSet/ech-7-cantonabbreviation')))"

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -10,6 +10,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * [#358](https://github.com/hl7ch/ch-core/issues/358): Entry Resource Cross References: Graphic added
 
 #### Fixed
+* [#354](https://github.com/hl7ch/ch-core/issues/354)/[#368](https://github.com/hl7ch/ch-core/issues/368)/[#388](https://github.com/hl7ch/ch-core/issues/388): Replace deprecated extension iso21090-SC-coding with iso21090-codedString
 * [#356](https://github.com/hl7ch/ch-core/issues/356): Invalid xhtml for UPI EPR Test Krcmarevic
 * [#364](https://github.com/hl7ch/ch-core/issues/364): Add missing extension context for ch-ext-author
 * [#363](https://github.com/hl7ch/ch-core/issues/363): Invalid extension context


### PR DESCRIPTION
…ring #354 #368 #388

- Updated alias in aliases.fsh to use iso21090-codedString
- Replaced all instance references in patient examples
- Updated invariant ch-addr-2 to use new extension URL
- Updated changelog to document this change

This addresses the deprecated extension warning from the STU 6 ballot.