### PR TITLE
Fix name extension binding strength from extensible to required #381

### DIFF
--- a/input/fsh/extensions/ECH011FirstName.fsh
+++ b/input/fsh/extensions/ECH011FirstName.fsh
@@ -11,7 +11,7 @@ Description: "eCH-0011: Extension to define first name type"
 * url only uri
 * valueCode 0..1
 * valueCode only code
-* valueCode from $ech-11-firstnamedatatype (extensible)
+* valueCode from $ech-11-firstnamedatatype (required)
 * valueCode ^short = "Value of extension"
 * valueCode ^definition = "Value of extension - may be a resource or one of a constrained set of the data types (see\r\n       Extensibility in the spec for list)."
 * valueCode ^binding.description = "A set of codes advising a system or user which name in a set of names to select for a\r\n         given purpose."

--- a/input/fsh/extensions/ECH011Name.fsh
+++ b/input/fsh/extensions/ECH011Name.fsh
@@ -10,7 +10,7 @@ Description: "eCH-0011: Extension to define name type"
 * url only uri
 * valueCode 0..1
 * valueCode only code
-* valueCode from $ech-11-namedatatype (extensible)
+* valueCode from $ech-11-namedatatype (required)
 * valueCode ^short = "Value of extension"
 * valueCode ^definition = "Value of extension - may be a resource or one of a constrained set of the data types (see\r\n       Extensibility in the spec for list)."
 * valueCode ^binding.description = "A set of codes advising a system or user which name in a set of names to select for a\r\n         given purpose."

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -12,6 +12,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * [#358](https://github.com/hl7ch/ch-core/issues/358): Entry Resource Cross References: Graphic added
 
 #### Fixed
+* [#381](https://github.com/hl7ch/ch-core/issues/381): Name extension binding strength changed from extensible to required (code data type cannot have extensible bindings)
 * [#354](https://github.com/hl7ch/ch-core/issues/354)/[#368](https://github.com/hl7ch/ch-core/issues/368)/[#388](https://github.com/hl7ch/ch-core/issues/388): Replace deprecated extension iso21090-SC-coding with iso21090-codedString
 * [#356](https://github.com/hl7ch/ch-core/issues/356): Invalid xhtml for UPI EPR Test Krcmarevic
 * [#364](https://github.com/hl7ch/ch-core/issues/364): Add missing extension context for ch-ext-author


### PR DESCRIPTION
## Summary
This PR fixes the binding strength for name-related extensions from `extensible` to `required`, addressing a technical inconsistency identified during the STU 6 ballot.

## Related Issue
Fixes #381 (negative vote)