### PR TITLE
Fix issues #385 and #386

### DIFF
--- a/ballots/6.0.0-ballot.md
+++ b/ballots/6.0.0-ballot.md
@@ -33,8 +33,8 @@ During the ballot, 31 issues were reported (see also [CH Core](https://github.co
 ### Terminology
 * [#122 Term](https://github.com/hl7ch/ch-term/issues/122): Code missing in ValueSet DocumentEntry.healthcareFacilityTypeCode
 * [#360](https://github.com/hl7ch/ch-core/issues/360): CH Core Composition EPR: VS binding (DocumentEntry.classCode, DocumentEntry.typeCode)
-* [#385](https://github.com/hl7ch/ch-core/issues/385): Use system https://www.gs1.org/gtin for Medication.code and Claim.productOrService <span style="color:red">(decided to keep OID)</span>
-* [#386](https://github.com/hl7ch/ch-core/issues/386): Use system http://www.gs1.org/gln for GLN identifiers <span style="color:red">(decided to keep OID)</span>
+* [#385](https://github.com/hl7ch/ch-core/issues/385): Use system https://www.gs1.org/gtin for Medication.code and Claim.productOrService
+* [#386](https://github.com/hl7ch/ch-core/issues/386): Use system http://www.gs1.org/gln for GLN identifiers
 
 ### Deprecated artifacts (dependencies)
 * [#371](https://github.com/hl7ch/ch-core/issues/371): Deprecations, see QA


### PR DESCRIPTION
hl7 core gorup decided to keep OID-based system identifiers instead of switching to HTTP URIs for both GTIN and GLN codes. Updated ballot documentation and changelog to reflect this decision.

- #385: Keep urn:oid:2.51.1.1 for GTIN codes
- #386: Keep urn:oid:2.51.1.3 for GLN identifiers
