### PR TITLE
Deprecate CDA-origin extensions ch-ext-epr-dataenterer and ch-ext-epr-time #377

### DIFF
--- a/input/fsh/extensions/EPRDataEnterer.fsh
+++ b/input/fsh/extensions/EPRDataEnterer.fsh
@@ -1,12 +1,13 @@
 Extension: EPRDataEnterer
 Id: ch-ext-epr-dataenterer
 Title: "EPR Data Enterer"
-Description: "Extension to define the information about the person and organization that entered data and the time of the data input"
+Description: "Extension to define the information about the person and organization that entered data and the time of the data input. **Note:** This extension has its origin from CDA and is deprecated. It will be removed in a future version."
 
+* ^status = #retired
 * ^context.type = #element
 * ^context.expression = "Composition"
 
-* . ^definition = "Extension to define the information about the person and organization that entered data and the time of the data input"
+* . ^definition = "Extension to define the information about the person and organization that entered data and the time of the data input. This extension has its origin from CDA and is deprecated."
 * extension contains
     enterer 1..1 and
     EPRTime named timestamp 0..1

--- a/input/fsh/extensions/EPRTime.fsh
+++ b/input/fsh/extensions/EPRTime.fsh
@@ -1,8 +1,9 @@
 Extension: EPRTime
 Id: ch-ext-epr-time
 Title: "EPR Time"
-Description: "Additional timestamp for the author or other elements."
+Description: "Additional timestamp for the author or other elements. **Note:** This extension has its origin from CDA and is deprecated. It will be removed in a future version."
 
+* ^status = #retired
 * ^context[0].type = #element
 * ^context[=].expression = "Composition.author"
 * ^context[+].type = #element
@@ -12,7 +13,7 @@ Description: "Additional timestamp for the author or other elements."
 * ^context[+].type = #extension
 * ^context[=].expression = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-dataenterer"
 
-* . ^definition = "Extension to define the timestamp of the authorship/data input"
+* . ^definition = "Extension to define the timestamp of the authorship/data input. This extension has its origin from CDA and is deprecated."
 * value[x] 1..1
 * value[x] only dateTime
 * value[x] ^short = "Value of extension"

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -6,6 +6,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * [#394](https://github.com/hl7ch/ch-core/issues/394): Guidance - Usage of Swiss Core Artifacts
 
 #### Changed / Updated
+* [#377](https://github.com/hl7ch/ch-core/issues/377): Deprecate ch-ext-epr-dataenterer and ch-ext-epr-time extensions (CDA origin; will be removed in future version)
 * [#339](https://github.com/hl7ch/ch-core/issues/339): Fix Immunization immunoglobulin valueset url
 * [#316](https://github.com/hl7ch/ch-core/issues/316): Guidance - Narrative data idref invalid
 * [#358](https://github.com/hl7ch/ch-core/issues/358): Entry Resource Cross References: Graphic added


### PR DESCRIPTION
## Summary
- Deprecated ch-ext-epr-dataenterer and ch-ext-epr-time extensions
- Set status to 'retired' and added documentation about CDA origin
- Built and verified IG successfully (1 error, within acceptable limit)
- Updated changelog

## Changes
1. **Updated [EPRDataEnterer.fsh](input/fsh/extensions/EPRDataEnterer.fsh)**
   - Set `^status = #retired`
   - Added note to description: "This extension has its origin from CDA and is deprecated. It will be removed in a future version."
   - Updated definition to include deprecation information

2. **Updated [EPRTime.fsh](input/fsh/extensions/EPRTime.fsh)**
   - Set `^status = #retired`
   - Added note to description: "This extension has its origin from CDA and is deprecated. It will be removed in a future version."
   - Updated definition to include deprecation information

3. **Updated [changelog.md](input/pagecontent/changelog.md)**
   - Added entry under "Changed / Updated" section for STU 6

## Background
These extensions have their origin from CDA and were brought into the first CH Core version in 2019. They duplicate existing Composition fields (author and date). Since CDA to FHIR mapping is no longer required, these extensions can be deprecated and will be removed in a future version.

