### PR TITLE
Update identifier validation constraints to align with eCH-0108 stand…

### DIFF
--- a/input/fsh/invariants/ahvn13-length.fsh
+++ b/input/fsh/invariants/ahvn13-length.fsh
@@ -1,4 +1,4 @@
 Invariant: ahvn13-length
-Description: "AHVN13 / NAVS13 must be exactly 13 characters long"
+Description: "AHVN13 / NAVS13 must start with 756 followed by 10 digits"
 Severity: #warning
-Expression: "matches('^[0-9]{13}$')"
+Expression: "matches('^756[0-9]{10}$')"

--- a/input/fsh/invariants/ahvn13-startswith756.fsh
+++ b/input/fsh/invariants/ahvn13-startswith756.fsh
@@ -1,4 +1,0 @@
-Invariant: ahvn13-startswith756
-Description: "AHVN13 / NAVS13 must start with 756"
-Severity: #warning
-Expression: "startsWith('756')"

--- a/input/fsh/invariants/ber.fsh
+++ b/input/fsh/invariants/ber.fsh
@@ -1,7 +1,7 @@
 Invariant: ber-length
-Description: "BER must start with a letter followed by 8 digits"
+Description: "BER must start with A or B, followed by a non-zero digit, then 7 more digits"
 Severity: #warning
-Expression: "matches('^[A-Z][0-9]{8}$')"
+Expression: "matches('^[A-B][1-9][0-9]{7}$')"
 
 Invariant: ber-modulus-11
 Description: "BER must pass the modulus 11 check"

--- a/input/fsh/invariants/epr-spid-length.fsh
+++ b/input/fsh/invariants/epr-spid-length.fsh
@@ -1,4 +1,4 @@
 Invariant: epr-spid-length
-Description: "EPR-SPID must be exactly 18 characters long"
+Description: "EPR-SPID must start with 76133761 followed by 10 digits"
 Severity: #warning
-Expression: "matches('^[0-9]{18}$')"
+Expression: "matches('^76133761[0-9]{10}$')"

--- a/input/fsh/invariants/epr-spid-startswith76133761.fsh
+++ b/input/fsh/invariants/epr-spid-startswith76133761.fsh
@@ -1,4 +1,0 @@
-Invariant: epr-spid-startswith76133761
-Description: "EPR-SPID must start with 76133761"
-Severity: #warning
-Expression: "startsWith('76133761')"

--- a/input/fsh/invariants/uidb.fsh
+++ b/input/fsh/invariants/uidb.fsh
@@ -1,7 +1,7 @@
 Invariant: uidb-length
-Description: "UIDB must start with 'CHE' followed by 9 digits"
+Description: "UIDB must start with 'CHE' followed by a non-zero digit, then 8 more digits"
 Severity: #warning
-Expression: "matches('^CHE[0-9]{9}$')"
+Expression: "matches('^CHE[1-9][0-9]{8}$')"
 
 Invariant: uidb-modulus-11
 Description: "UIDB must pass the modulus 11 check"

--- a/input/fsh/invariants/veka-length.fsh
+++ b/input/fsh/invariants/veka-length.fsh
@@ -1,4 +1,4 @@
 Invariant: veka-length
-Description: "Insurance card number must be exactly 20 characters long"
+Description: "Insurance card number must start with 807560 followed by 14 digits"
 Severity: #warning
-Expression: "matches('^[0-9]{20}$')"
+Expression: "matches('^807560[0-9]{14}$')"

--- a/input/fsh/invariants/veka-startswith807560.fsh
+++ b/input/fsh/invariants/veka-startswith807560.fsh
@@ -1,4 +1,0 @@
-Invariant: veka-startswith807560
-Description: "Insurance card number must start with 807560"
-Severity: #warning
-Expression: "startsWith('807560')"

--- a/input/fsh/profiles-datatypes/Identifier.fsh
+++ b/input/fsh/profiles-datatypes/Identifier.fsh
@@ -8,7 +8,7 @@ Description: "Identifier holding a 13 digit social security number. The number s
 * system 1..
 * system = "urn:oid:2.16.756.5.32" (exactly)
 * value 1..
-* value obeys ahvn13-length and ahvn13-startswith756 and ahvn13-digit-check
+* value obeys ahvn13-length and ahvn13-digit-check
 
 Profile: EPRSPIDIdentifier
 Parent: Identifier
@@ -18,17 +18,17 @@ Description: "EPR-SPID Identifier (https://www.fedlex.admin.ch/eli/cc/2017/205/d
 * system 1..
 * system = "urn:oid:2.16.756.5.30.1.127.3.10.3" (exactly)
 * value 1..
-* value obeys epr-spid-length and epr-spid-startswith76133761 and epr-spid-modulus-10
+* value obeys epr-spid-length and epr-spid-modulus-10
 
 Profile: VEKAIdentifier
 Parent: Identifier
 Id: ch-core-veka-identifier
 Title: "Insurance Card Number (Identifier)"
-Description: "Identifier in 20-digit format. The number shall have exactly 20 digits and start with 756."
+Description: "Identifier in 20-digit format. The number shall have exactly 20 digits and start with 807560."
 * system 1..
 * system = "urn:oid:2.16.756.5.30.1.123.100.1.1.1" (exactly)
 * value 1..
-* value obeys veka-length and veka-startswith807560
+* value obeys veka-length
 * period.end ^short = "Expiration date of the insurance card"
 
 

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -11,6 +11,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * [#358](https://github.com/hl7ch/ch-core/issues/358): Entry Resource Cross References: Graphic added
 
 #### Fixed
+* [#372](https://github.com/hl7ch/ch-core/issues/372): Update identifier validation constraints to align with eCH-0108 standard (BER, UIDB regex patterns made more restrictive; AHVN13, VEKA, EPR-SPID constraints consolidated into single regex patterns)
 * [#381](https://github.com/hl7ch/ch-core/issues/381): Name extension binding strength changed from extensible to required (code data type cannot have extensible bindings)
 * [#354](https://github.com/hl7ch/ch-core/issues/354)/[#368](https://github.com/hl7ch/ch-core/issues/368)/[#388](https://github.com/hl7ch/ch-core/issues/388): Replace deprecated extension iso21090-SC-coding with iso21090-codedString
 * [#356](https://github.com/hl7ch/ch-core/issues/356): Invalid xhtml for UPI EPR Test Krcmarevic


### PR DESCRIPTION
…ard #372

This commit updates the identifier validation patterns for Swiss healthcare identifiers to align with the eCH-0108 standard:

- BER Identifier: Updated regex from ^[A-Z][0-9]{8}$ to ^[A-B][1-9][0-9]{7}$ to restrict first letter to A or B and require first digit to be non-zero

- UIDB Identifier: Updated regex from ^CHE[0-9]{9}$ to ^CHE[1-9][0-9]{8}$ to require first digit after CHE to be non-zero

- AHVN13 Identifier: Consolidated ahvn13-length and ahvn13-startswith756 constraints into single regex ^756[0-9]{10}$

- VEKA Identifier: Consolidated veka-length and veka-startswith807560 constraints into single regex ^807560[0-9]{14}$

- EPR-SPID Identifier: Consolidated epr-spid-length and epr-spid-startswith76133761 constraints into single regex ^76133761[0-9]{10}$

All changes are warnings rather than errors, minimizing implementation risk.