### PR TITLE
Relax HumanName rule for EPR Patient and Practitioner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,10 @@
 ## Commit & Pull Request Guidelines
 - When creating a new PR or commit first run npm build:ig, this can take a few minutes, only commit when the error count is not bigger than 1, analyze output/qa.html for detailed error message
 - Branch names: Use underscores instead of slashes (e.g., `issue123_fix_extension` not `issue/123/fix-extension`). Slashes in branch names can cause issues with ci-build.
-- Commits: Concise, imperative summaries (e.g., "Fix name extension binding strength").
+- Commits: Concise, imperative summaries (e.g., "Fix name extension binding strength"). Claude needs not to be mentioned.
 - Reference issues in commits (e.g., "#381").
 - Update changelog in input/pagecontent/changelog.md
-- PRs: Include purpose, scope, linked issues, and impact.
+- PRs: Include purpose, scope, linked issues, keep it short, Claude needs not to be mentioned as co-author.
 
 ## Security & Configuration Tips
 - IG build contacts `tx.fhir.org` for terminology; offline builds pass `-tx n/a`.

--- a/input/fsh/invariants/ch-pat-1_ch-pat-1-epr.fsh
+++ b/input/fsh/invariants/ch-pat-1_ch-pat-1-epr.fsh
@@ -4,6 +4,6 @@ Severity: #warning
 Expression: "name.where(family.exists() and given.exists()).count()>0 or name.empty()"
 
 Invariant: ch-pat-1-epr
-Description: "At least one human name shall have a family and a given name."
+Description: "At least one human name shall have a family name."
 Severity: #error
-Expression: "name.where(family.exists() and given.exists()).count()>0"
+Expression: "name.where(family.exists()).count()>0"

--- a/input/fsh/invariants/ch-pract-1.fsh
+++ b/input/fsh/invariants/ch-pract-1.fsh
@@ -1,4 +1,4 @@
 Invariant: ch-pract-1
-Description: "If a HumanName is provided, at least one HumanName must have a given and family name."
+Description: "If a HumanName is provided, at least one HumanName must have a family name."
 Severity: #error
-Expression: "name.where(family.exists() and given.exists()).count()>0 or name.empty()"
+Expression: "name.where(family.exists()).count()>0 or name.empty()"

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -6,6 +6,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * [#394](https://github.com/hl7ch/ch-core/issues/394): Guidance - Usage of Swiss Core Artifacts
 
 #### Changed / Updated
+* [#416](https://github.com/hl7ch/ch-core/issues/416): Relax HumanName rule for EPR Patient and Practitioner (require only family name, not given name)
 * [#359](https://github.com/hl7ch/ch-core/issues/359): Updated ICD-10-GM CodeSystem URL from dimdi to bfarm (http://fhir.de/CodeSystem/bfarm/icd-10-gm)
 * [#379](https://github.com/hl7ch/ch-core/issues/379): Allow multiple legal authenticators
 * [#382](https://github.com/hl7ch/ch-core/issues/382): Allow multiple preferred languages by removing communication slicing constraint


### PR DESCRIPTION
## Summary
- Relaxes `ch-pat-1-epr` invariant to require only family name (removes given name requirement)
- Relaxes `ch-pract-1` invariant to require only family name (removes given name requirement)
- Aligns with XDS requirements where lastname is sufficient for specifying authors

Fixes #416