### PR TITLE
Remove Coverage.class.type binding override

### DIFF
--- a/input/fsh/profiles-resources/CHCoreCoverage.fsh
+++ b/input/fsh/profiles-resources/CHCoreCoverage.fsh
@@ -22,6 +22,5 @@ Description: "Base definition of the Coverage resource for use in Swiss specific
 * payor ^short = "Issuer of the policy (if it is not the patient him/herself, represent the payor as a contained resource)"
 * payor ^type.aggregation[0] = #contained
 * payor ^type.aggregation[+] = #referenced
-* type from http://fhir.ch/ig/ch-term/ValueSet/mainguarantor (preferred)
-* class.type from http://fhir.ch/ig/ch-core/ValueSet/bfs-medstats-21-encountertype (extensible) // Cannot override extensible binding with preferred binding. 
+* type from http://fhir.ch/ig/ch-term/ValueSet/mainguarantor (preferred) 
 

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -18,6 +18,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * [#358](https://github.com/hl7ch/ch-core/issues/358): Entry Resource Cross References: Graphic added
 
 #### Fixed
+* [#398](https://github.com/hl7ch/ch-core/issues/398): Remove Coverage.class.type binding override (invalid to rebind extensible ValueSet to different extensible ValueSet)
 * [#373](https://github.com/hl7ch/ch-core/issues/373): Require value[x] for simple extensions
 * [#372](https://github.com/hl7ch/ch-core/issues/372): Update identifier validation constraints to align with eCH-0108 standard (BER, UIDB regex patterns made more restrictive; AHVN13, VEKA, EPR-SPID constraints consolidated into single regex patterns)
 * [#381](https://github.com/hl7ch/ch-core/issues/381): Name extension binding strength changed from extensible to required (code data type cannot have extensible bindings)


### PR DESCRIPTION
## Summary
- Remove `Coverage.class.type` binding override from CH Core Coverage profile
- Per FHIR terminology rules, extensible bindings cannot be overridden with different extensible ValueSets

Fixes #398