### PR TITLE
Remove deprecated CDA extension usage from examples (#377)

### DIFF
--- a/input/examples/Bundle-DocumentContainingOriginalRepresentationAsPdfA.xml
+++ b/input/examples/Bundle-DocumentContainingOriginalRepresentationAsPdfA.xml
@@ -23,16 +23,6 @@
             <reference value="urn:uuid:e118f753-caaa-4696-991a-b20a796ce782"/>
           </valueReference>
         </extension>
-        <extension url="http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-dataenterer">
-          <extension url="enterer">
-            <valueReference>
-              <reference value="urn:uuid:cac33923-b081-4060-bd57-46ee35dd5a33"/>
-            </valueReference>
-          </extension>
-          <extension url="http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-time">
-            <valueDateTime value="2017-10-03T13:15:00+01:00"/>
-          </extension>
-        </extension>
         <identifier>
           <system value="urn:ietf:rfc:3986"/>
           <value value="urn:uuid:11778932-3d19-486b-afe6-e32a1165c978"/>
@@ -55,9 +45,6 @@
         </subject>
         <date value="2018-02-06T16:57:00+01:00"/>
         <author>
-          <extension url="http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-time">
-            <valueDateTime value="2017-10-03T16:09:00+01:00"/>
-          </extension>
           <reference value="urn:uuid:5e5d0948-61b0-4555-9a8f-40bacdc0cb8c"/>
         </author>
         <author>
@@ -342,35 +329,6 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:cac33923-b081-4060-bd57-46ee35dd5a33"/>
-    <resource>
-      <PractitionerRole>
-        <id value="cac33923-b081-4060-bd57-46ee35dd5a33"/>
-        <practitioner>
-          <reference value="urn:uuid:be3ba855-6bef-4c36-92a1-8b76fefd3629"/>
-          <type value="Practitioner"/>
-        </practitioner>
-      </PractitionerRole>
-    </resource>
-  </entry>
-  <entry>
-    <fullUrl value="urn:uuid:be3ba855-6bef-4c36-92a1-8b76fefd3629"/>
-    <resource>
-      <Practitioner>
-        <id value="be3ba855-6bef-4c36-92a1-8b76fefd3629"/>
-        <identifier>
-          <system value="urn:oid:2.999.1.2.3.4"/>
-          <value value="0812763"/>
-        </identifier>
-        <name>
-          <use value="official"/>
-          <family value="Kristin"/>
-          <given value="Stabilo"/>
-        </name>
-      </Practitioner>
-    </resource>
-  </entry>
-  <entry id="8f304c87-ed20-4e9a-b928-db4116eb6594">
     <fullUrl value="urn:uuid:8f304c87-ed20-4e9a-b928-db4116eb6594"/>
     <resource>
       <Binary>

--- a/input/fsh/instances/composition/ZuweisungZurRadiologischenDiagnostik.fsh
+++ b/input/fsh/instances/composition/ZuweisungZurRadiologischenDiagnostik.fsh
@@ -8,11 +8,6 @@ Description: "Composition EPR with the information about the transfer in differe
 * language = #de-CH
 * extension[0].url = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-informationrecipient"
 * extension[=].valueReference = Reference(Radiologieinstitut)
-* extension[+].extension[0].url = "enterer"
-* extension[=].extension[=].valueReference = Reference(PractitionerRole/SchreibKraftAtGruppenpraxisCH)
-* extension[=].extension[+].url = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-time"
-* extension[=].extension[=].valueDateTime = "2017-10-03T13:15:00+01:00"
-* extension[=].url = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-dataenterer"
 * identifier.system = "urn:ietf:rfc:3986"
 * identifier.value = "urn:uuid:31397b31-be60-47e1-bec6-f37816d42b0c"
 * status = #final
@@ -20,8 +15,6 @@ Description: "Composition EPR with the information about the transfer in differe
 * type.coding[+] = $sct#371535009 "Transfer summary report"
 * subject = Reference(MaxMuster)
 * date = "2017-10-03T17:33:00+01:00"
-* author.extension.url = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-time"
-* author.extension.valueDateTime = "2017-10-03T16:09:00+01:00"
 * author = Reference(AllzeitBereit)
 * title = "Zuweisung zur Radiologischen Diagnostik"
 * confidentiality.extension.url = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-confidentialitycode"

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -6,7 +6,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * [#394](https://github.com/hl7ch/ch-core/issues/394): Guidance - Usage of Swiss Core Artifacts
 
 #### Changed / Updated
-* [#377](https://github.com/hl7ch/ch-core/issues/377): Deprecate ch-ext-epr-dataenterer and ch-ext-epr-time extensions (CDA origin; will be removed in future version)
+* [#377](https://github.com/hl7ch/ch-core/issues/377): Deprecate ch-ext-epr-dataenterer and ch-ext-epr-time extensions (CDA origin; will be removed in future version); remove usage from examples
 * [#339](https://github.com/hl7ch/ch-core/issues/339): Fix Immunization immunoglobulin valueset url
 * [#316](https://github.com/hl7ch/ch-core/issues/316): Guidance - Narrative data idref invalid
 * [#358](https://github.com/hl7ch/ch-core/issues/358): Entry Resource Cross References: Graphic added


### PR DESCRIPTION
## Summary
This PR removes usage of the deprecated `ch-ext-epr-dataenterer` and `ch-ext-epr-time` extensions from example instances, as decided in the telco (see issue #377).

## Changes
- Removed `ch-ext-epr-dataenterer` and `ch-ext-epr-time` extensions from `ZuweisungZurRadiologischenDiagnostik.fsh`
- Removed `ch-ext-epr-dataenterer` and `ch-ext-epr-time` extensions from `Bundle-DocumentContainingOriginalRepresentationAsPdfA.xml`
- Removed unreferenced PractitionerRole and Practitioner entries from the Bundle (no longer referenced after removing the dataenterer extension)
- Updated changelog to document the removal from examples

## Background
These extensions were previously deprecated (marked as retired) as they have their origin from CDA and will be removed in a future version. This PR completes the work by removing their usage from example files.

## Testing
- IG build completed successfully
- Error count reduced from 3 to 1 (remaining error is pre-existing and unrelated to these changes)
- No broken links

## Related Issues
Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)