### PR TITLE
Replace the AHVN13 default example with a valid one

### DIFF
--- a/input/fsh/profiles-datatypes/Identifier.fsh
+++ b/input/fsh/profiles-datatypes/Identifier.fsh
@@ -9,6 +9,10 @@ Description: "Identifier holding a 13 digit social security number. The number s
 * system = "urn:oid:2.16.756.5.32" (exactly)
 * value 1..
 * value obeys ahvn13-length and ahvn13-digit-check
+* value ^example[0].extension[+].url = "http://hl7.org/fhir/StructureDefinition/elementdefinition-suppress"
+* value ^example[0].extension[=].valueBoolean = true
+* value ^example[+].label = "of valid AHVN13"
+* value ^example[=].valueString = "7561234567897"
 
 Profile: EPRSPIDIdentifier
 Parent: Identifier

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -76,6 +76,7 @@ parameters:
     - urn:oid:2.16.756.5.30.1.127.3.10.10
     - http://fhir.ch/ig/ch-emed/StructureDefinition/ch-emed-ext-substitution
     - http://fhir.ch/ig/ch-emed/StructureDefinition/ch-emed-ext-treatmentreason
+    - http://hl7.org/fhir/StructureDefinition/elementdefinition-suppress
   allow-extensible-warnings: true
   display-warnings: true  
   path-expansion-params: '../../expansion-params.json'  # for using SNOMED CT Swiss Extension


### PR DESCRIPTION
Fixes #428

Preview: [AHVN13Identifier](https://build.fhir.org/ig/hl7ch/ch-core/branches/428-ahvn13-navs13-identifier-gabriel-hess-berner-fachhochschule/StructureDefinition-ch-core-ahvn13-identifier.html)
[QA](https://build.fhir.org/ig/hl7ch/ch-core/branches/428-ahvn13-navs13-identifier-gabriel-hess-berner-fachhochschule/qa.html)

Uses the [FHIR extension pack](http://hl7.org/fhir/extensions/StructureDefinition-elementdefinition-suppress.html), as described in this [Zulip thread](https://chat.fhir.org/#narrow/channel/196008-ig-publishing-requirements/topic/.22Example.20General.22.20showing.20in.20my.20diff.20view).

<img width="572" height="60" alt="image" src="https://github.com/user-attachments/assets/4dcca775-df7d-4fc7-86ad-816d3be958fb" />
