### PR TITLE
Update dependencies: hl7.terminology.r4 7.1.0, hl7.fhir.uv.extensions.r4 5.3.0

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -6,6 +6,8 @@ All significant changes to this FHIR implementation guide will be documented on 
 #### Changed
 * [#430](https://github.com/hl7ch/ch-core/issues/430): CH Core Immunization - ValueSet: CH VACD Swissmedic Authorized Immunsera Codes
 * [#425](https://github.com/hl7ch/ch-core/issues/425): CH Core Immunization - add binding to NUVA CodeSystem for vaccineCode
+* Update dependency hl7.terminology.r4 from 7.0.1 to 7.1.0
+* Update dependency hl7.fhir.uv.extensions.r4 from 5.3.0-ballot-tc1 to 5.3.0
 
 ### STU 6 (2025-12-16)
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -28,10 +28,10 @@ dependencies:
   ch.fhir.ig.ch-term: 3.3.x
   hl7.terminology.r4: 
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
-    version: 7.0.1  
+    version: 7.1.0
   hl7.fhir.uv.extensions.r4:  
     uri: http://hl7.org/fhir/extensions/ImplementationGuide/hl7.fhir.uv.extensions
-    version: 5.3.0-ballot-tc1 
+    version: 5.3.0
 
 pages:
   index.md:


### PR DESCRIPTION
## Summary
- Bump `hl7.terminology.r4` from `7.0.1` to `7.1.0`
- Bump `hl7.fhir.uv.extensions.r4` from `5.3.0-ballot-tc1` to `5.3.0`