### PR TITLE
Enhance GeneralConsent with organization reference and examples

### DIFF
--- a/input/fsh/VS_ConsentGCStateCodesVS.fsh
+++ b/input/fsh/VS_ConsentGCStateCodesVS.fsh
@@ -1,0 +1,6 @@
+ValueSet:    CHCoreGeneralConsentStateVS
+Id:          CHCoreGeneralConsentStateVS
+Title:       "CH Core General Consent State"
+Description: "Allowed status values for CH Core General Consent: only active and inactive."
+* http://hl7.org/fhir/consent-state-codes#active
+* http://hl7.org/fhir/consent-state-codes#inactive

--- a/input/fsh/instances/consent/EX_examples.fsh
+++ b/input/fsh/instances/consent/EX_examples.fsh
@@ -1,10 +1,10 @@
 Instance: GC-accepted
-InstanceOf: CHCoreConsent
+InstanceOf: CHCoreGeneralConsent
 Usage: #example
 Title: "General Consent accepted"
 Description: "Example of a General Consent accepted by the patient"
 * status = #active
-* scope = $consentscope#patient-privacy
+* scope = $consentscope#research
 * category.coding.system = $loinc
 * category.coding.code = #59284-0 //Patient Consent
 * patient.reference = "Patient/MaxMuster" //R5 'subject' -> R4 'patient'
@@ -44,12 +44,12 @@ Description: "Example of a General Consent accepted by the patient"
 
 
 Instance: GC-denied
-InstanceOf: CHCoreConsent
+InstanceOf: CHCoreGeneralConsent
 Usage: #example
 Title: "General Consent denied"
 Description: "Example of a General Consent denied by a legal representative"
 * status = #active
-* scope = $consentscope#patient-privacy
+* scope = $consentscope#research
 * category.coding.system = $loinc
 * category.coding.code = #59284-0 //Patient Consent
 * patient.reference = "Patient/MaxMuster"

--- a/input/fsh/profiles-resources/CHCoreGeneralConsent.fsh
+++ b/input/fsh/profiles-resources/CHCoreGeneralConsent.fsh
@@ -1,0 +1,51 @@
+Profile:        CHCoreGeneralConsent
+Parent:         CHCoreConsent
+Id:             CHCoreGeneralConsent
+Title:          "CH Core General Consent (Unimedsuisse Generalkonsent)"
+Description:    "Specialization of CHCoreConsent for the Unimedsuisse Generalkonsent (GC)."
+
+// --- status: only active | inactive in the GC context ---
+// Semantics:
+//   active   = GC granted or rejected (a decision has been recorded)
+//   inactive = GC withdrawn or canceled
+//   "unknown" corresponds to the absence of a Consent resource
+* status from CHCoreGeneralConsentStateVS (required)
+* status ^short = "active | inactive (GC-specific subset of ConsentState)"
+* status ^definition = "active = GC granted/rejected; inactive = GC withdrawn/canceled. The absence of a Consent resource corresponds to the state 'unknown' (no GC recorded yet)."
+
+// --- date: mandatory, cardinality 1..1 ---
+* dateTime 1..1
+* dateTime ^short = "Date the consent entry was made (mandatory)"
+* dateTime ^definition = "Represents the date when the entry to the system was made. Mandatory in the GC context."
+
+* scope = $consentscope#research
+
+// --- policyBasis: fixed URL to Unimedsuisse Generalkonsent ---
+// Mapped onto R4 via Consent.policy.uri (functional equivalent of R5 policyBasis.url)
+* policy 1..1
+* policy ^short = "Computable backing policy (Unimedsuisse Generalkonsent)"
+* policy.uri 1..1
+* policy.uri = "https://www.unimedsuisse.ch/de/projekte/generalkonsent"
+
+// --- grantee: only Organization, HealthcareService alternate-reference forbidden ---
+* performer ^short = "Grantee (Organization). HealthcareService grantees are NOT allowed in this profile."
+* performer.extension contains
+    http://hl7.org/fhir/StructureDefinition/alternate-reference named alternateRef 0..0
+* performer.extension[alternateRef] ^short = "Forbidden: HealthcareService as grantee is excluded in the CH Core General Consent."
+
+// --- provision.purpose: must be HRESCH (healthcare research, CH) ---
+* provision.purpose 1..
+* provision.purpose ^short = "Context of activities covered by this provision (must be HRESCH)"
+* provision.purpose ^definition = "Purpose of use is fixed to HRESCH in the Unimedsuisse Generalkonsent."
+* provision.purpose.system 1..1
+* provision.purpose.system = "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+* provision.purpose.code 1..1
+* provision.purpose.code = #HRESCH
+
+// --- decision: semantic annotation ---
+// In R4 the base decision is expressed via provision.type (deny|permit).
+// GC-specific reading according to CH Core General Consent:
+//   deny   = GC granted (provisions describe exceptions to the base 'deny')
+//   permit = GC rejected
+* provision.type ^short = "deny = GC granted | permit = GC rejected"
+* provision.type ^definition = "Base decision for the General Consent. GC-specific semantics: deny = GC granted (provisions describe exceptions), permit = GC rejected. See Unimedsuisse Generalkonsent specification."

--- a/input/fsh/profiles-resources/SD_CoreConsent.fsh
+++ b/input/fsh/profiles-resources/SD_CoreConsent.fsh
@@ -15,7 +15,7 @@ Description: "Base definition of the Consent resource for use in Swiss specific 
 * patient ^short = "The patient to whom this consent applies to"
 
 // R5 'grantor' via xver extension
-* extension[grantor].valueReference only Reference(Patient or RelatedPerson)
+* extension[grantor].valueReference only Reference(Patient or RelatedPerson or Organization)
 
 // R5 'grantee' maps to R4 'performer'. R4 performer cannot reference HealthcareService directly;
 // use the standard alternate-reference extension on performer for HealthcareService grantees.


### PR DESCRIPTION
Added organization to grantor: * extension[grantor].valueReference only Reference(Patient or RelatedPerson or Organization) it is required for patient portal later

Added profile for GeneralConsent along with GCStateCodesVS

Added scope to examples, made GCExamples parent GeneralConsent