### PR TITLE
Prepare 7.0.0-ballot for publication

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,6 +1,6 @@
 All significant changes to this FHIR implementation guide will be documented on this page.
 
-### STU 7 Ballot (2026-06-22)
+### STU 7 Ballot (2026-06-10)
 
 #### Added
 * [#432](https://github.com/hl7ch/ch-core/issues/432):

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,6 +1,6 @@
 All significant changes to this FHIR implementation guide will be documented on this page.
 
-### STU 7 Ballot (unreleased)
+### STU 7 Ballot (2026-06-22)
 
 #### Added
 * [#432](https://github.com/hl7ch/ch-core/issues/432):

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -13,6 +13,9 @@ This guide is a working specification. We anticipate that it will be implemented
 
 <div markdown="1" class="stu-note">
 
+This implementation guide is under STU ballot by [HL7 Switzerland](https://www.hl7.ch/) from August 4th, 2026 until September 30th, 2026.
+Please add your feedback via the 'Propose a change'-link in the footer.
+
 [Changelog](changelog.html) with significant changes, open and closed issues.
 
 </div>

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,11 +1,11 @@
 {
   "package-id" : "ch.fhir.ig.ch-core",
-  "version" : "6.0.0",
-  "path" : "http://fhir.ch/ig/ch-core/6.0.0",
+  "version" : "7.0.0-ballot",
+  "path" : "http://fhir.ch/ig/ch-core/7.0.0-ballot",
   "mode" : "milestone",
-  "status" : "trial-use",
-  "sequence" : "STU 6",
-  "desc" : "HL7 Switzerland STU 6",
+  "status" : "ballot",
+  "sequence" : "STU 7",
+  "desc" : "HL7 Switzerland STU 7 Ballot",
   "changes" : "changelog.html",
   "first": false
 }

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -25,7 +25,7 @@ copyright: CC0-1.0
 jurisdiction: urn:iso:std:iso:3166#CH
 
 dependencies:
-  ch.fhir.ig.ch-term: 3.4.0
+  ch.fhir.ig.ch-term: 3.4.x
   hl7.terminology.r4: 
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
     version: 7.1.0

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -6,11 +6,11 @@ title: CH Core (R4)
 description: FHIR implementation guide CH Core
 status: active
 experimental: false
-date: 2025-12-16
-version: 7.0.0-ballot-ci-build
+date: 2026-06-22
+version: 7.0.0-ballot
 fhirVersion: 4.0.1
 copyrightYear: 2020+
-releaselabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaselabel: ballot # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 publisher:
   name: HL7 Switzerland
   url: https://www.hl7.ch/
@@ -25,7 +25,7 @@ copyright: CC0-1.0
 jurisdiction: urn:iso:std:iso:3166#CH
 
 dependencies:
-  ch.fhir.ig.ch-term: 3.3.x
+  ch.fhir.ig.ch-term: 3.4.0
   hl7.terminology.r4: 
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
     version: 7.1.0

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -6,7 +6,7 @@ title: CH Core (R4)
 description: FHIR implementation guide CH Core
 status: active
 experimental: false
-date: 2026-06-22
+date: 2026-06-10
 version: 7.0.0-ballot
 fhirVersion: 4.0.1
 copyrightYear: 2020+


### PR DESCRIPTION
## Summary

Prepare CH Core for 7.0.0-ballot publication on fhir.ch (2026-06-22).

- Update `sushi-config.yaml`: version → `7.0.0-ballot`, date → `2026-06-22`, releaselabel → `ballot`
- Update dependency `ch.fhir.ig.ch-term` from `3.3.x` to `3.4.0` (published 2026-06-10)
- Update `publication-request.json` for STU 7 ballot
- Add ballot notice to `index.md` (ballot period: August 4 – September 30, 2026)